### PR TITLE
feat: surveys to use PII process table to remove PII

### DIFF
--- a/dpanonymize/__init__.py
+++ b/dpanonymize/__init__.py
@@ -72,8 +72,8 @@ def get_file_objects_from_phoenix(root_dir: Union[Path, str],
     '''Search all files under phoenix and get a list of FileInPhoenix objects
 
     Key Arguments
-        - root_dir: root of PHOENIX directory structure to search files
-                          from, Path or str.
+        - root_dir: 'PROTECTED' directory PHOENIX structure to search files
+                    which is used in creating FileInPhoenix objects, str.
         - BIDS: True if the PHOENIX is in BIDS structure, bool.
     '''
     protected_files = []
@@ -94,8 +94,8 @@ def get_file_objects_from_module(root_dir: Union[Path, str],
     '''Search all files under phoenix and get a list of FileInPhoenix objects
 
     Key Arguments:
-        - root_dir: root of PHOENIX directory structure to search files
-                          from, Path or str.
+        - root_dir: 'PROTECTED' directory of PHOENIX structure to search files
+                    which is used in creating FileInPhoenix objects, str.
         - module: name of the module to remove PII from, str.
         - BIDS: True if the PHOENIX is in BIDS structure, bool.
     '''
@@ -141,6 +141,9 @@ def lock_lochness(Lochness: 'Lochness',
         pii_table_loc = phoenix_root.parent / 'pii_convert.csv'
         df.to_csv(pii_table_loc)
 
+    # get_file_objects_from_phoenix and get_file_objects_from_module takes
+    # PROTECTED path, but FileInPhoenixBIDS and FileInPhoenix are designed
+    # to set both GENERAL & PROTECTED paths.
     file_object_list = get_file_objects_from_phoenix(protected_root, bids) \
         if module is None else \
         get_file_objects_from_module(protected_root, module, bids)

--- a/dpanonymize/__init__.py
+++ b/dpanonymize/__init__.py
@@ -45,10 +45,7 @@ class FileInPhoenixBIDS(object):
         module = dtype_module_dict.get(self.dtype)
 
         if self.dtype == 'surveys':
-            pii_table_loc = kwargs.get(
-                'pii_table_loc',
-                self.file_path.parent.parent.parent.parent.parent.parent / \
-                        'pii_table.csv')
+            pii_table_loc = kwargs.get('pii_table_loc', False)
 
             module.process_and_copy_db(
                     pii_table_loc,

--- a/dpanonymize/__init__.py
+++ b/dpanonymize/__init__.py
@@ -72,8 +72,8 @@ def get_file_objects_from_phoenix(root_dir: Union[Path, str],
     '''Search all files under phoenix and get a list of FileInPhoenix objects
 
     Key Arguments
-        - root_dir: 'PROTECTED' directory PHOENIX structure to search files
-                    which is used in creating FileInPhoenix objects, str.
+        - root_dir: 'PROTECTED' directory of PHOENIX structure to search files
+                    which are used to create FileInPhoenix objects, str.
         - BIDS: True if the PHOENIX is in BIDS structure, bool.
     '''
     protected_files = []
@@ -95,7 +95,7 @@ def get_file_objects_from_module(root_dir: Union[Path, str],
 
     Key Arguments:
         - root_dir: 'PROTECTED' directory of PHOENIX structure to search files
-                    which is used in creating FileInPhoenix objects, str.
+                    which are used to create FileInPhoenix objects, str.
         - module: name of the module to remove PII from, str.
         - BIDS: True if the PHOENIX is in BIDS structure, bool.
     '''

--- a/dpanonymize/surveys/__init__.py
+++ b/dpanonymize/surveys/__init__.py
@@ -208,7 +208,7 @@ def process_and_copy_db(pii_table_loc: Union[str, Path], subject_name: str,
         proc_dst: processed data out destination, str or Path.
     '''
     # don't run this if the pii_table in the config.yml is missing
-    if pii_table_loc is not False and pii_table_loc != '':
+    if pii_table_loc:
         # make output directory
         Path(proc_dst).parent.mkdir(exist_ok=True, parents=True)
 

--- a/dpanonymize/surveys/__init__.py
+++ b/dpanonymize/surveys/__init__.py
@@ -9,14 +9,7 @@ from typing import Union, List
 import re
 import sys
 import shutil
-
-
-def remove_pii(data_in: Union[str, Path], data_out: Union[str, Path]):
-    '''Remove PII from actigraphy data - place holder'''
-    if not Path(data_out).parent.is_dir():
-        Path(data_out).parent.mkdir(parents=True, exist_ok=True)
-    shutil.copy(data_in, data_out)
-
+from json import JSONDecodeError
 
 class PiiTableError(Exception):
     pass
@@ -65,9 +58,13 @@ def load_raw_return_proc_json(json_loc: str,
                               subject_id: str) -> List[dict]:
     # load json in PROTECTED/surveys/raw
     with open(json_loc, 'r') as f:
-        raw_json = json.load(f)  # list of dicts
+        try:
+            raw_json = json.load(f)  # list of dicts
+            processed_json = []
+        except JSONDecodeError: # when the raw json file is empty or broken
+            raw_json = []
+            processed_json = [{'note':'raw_file_was_empty_or_broken'}]
 
-    processed_json = []
     for instrument in raw_json:
         processed_instrument = {}
         for field_name, field_value in instrument.items():
@@ -199,18 +196,28 @@ def load_raw_return_proc_csv(csv_loc: str,
     return raw_df_subject
 
 
-def process_and_copy_db(Lochness, subject, raw_input, proc_dst):
-    '''Process PII and copy the json to GENERAL/surveys/processed'''
-    pii_table_loc = get_PII_table_loc(Lochness, subject.study)
+def process_and_copy_db(pii_table_loc: Union[str, Path], subject_name: str,
+                        raw_input: Union[str, Path],
+                        proc_dst: Union[str, Path]):
+    '''Process PII and copy the json to GENERAL/surveys/processed
 
+    Key Arguments:
+        pii_table_loc: path of the pii table, str or Path.
+        subject_name: subject name to be used in the string replacement, str.
+        raw_input: raw data in, str or Path.
+        proc_dst: processed data out destination, str or Path.
+    '''
     # don't run this if the pii_table in the config.yml is missing
-    if pii_table_loc != False and pii_table_loc != '':
+    if pii_table_loc is not False and pii_table_loc != '':
+        # make output directory
+        Path(proc_dst).parent.mkdir(exist_ok=True, parents=True)
+
         # process PII here
         pii_str_proc_dict = read_pii_mapping_to_dict(pii_table_loc)
 
         if str(raw_input).endswith('json'):
             processed_content = load_raw_return_proc_json(
-                    raw_input, pii_str_proc_dict, subject.id)
+                    raw_input, pii_str_proc_dict, subject_name)
 
             # double check the pii string processing dict once more
             # if it's empty, don't copy it over to general
@@ -219,13 +226,15 @@ def process_and_copy_db(Lochness, subject, raw_input, proc_dst):
 
         elif str(raw_input).endswith('csv'):
             processed_df = load_raw_return_proc_csv(
-                    raw_input, pii_str_proc_dict, subject.id)
+                    raw_input, pii_str_proc_dict, subject_name)
 
             # double check the pii string processing dict once more
             # if it's empty, don't copy it over to general
             if pii_str_proc_dict != {}:
                 processed_df.to_csv(proc_dst, index=False)
-
+    else:
+        raise PiiTableError('Please provide correct location of the PII '
+                            'process table')
 
 
 def get_PII_table_loc(Lochness, study):

--- a/scripts/dpanon.py
+++ b/scripts/dpanon.py
@@ -80,7 +80,7 @@ def parse_args(argv):
             choices=['surveys', 'video', 'audio', 'actigraphy', 'mri', 'eeg'],
             help='Datatype to remove PII (applies to -p, -i).')
     parser.add_argument(
-            '-ptl', '--pii_table_loc', default=False,
+            '-pt', '--pii_table_loc', default=False,
             help='Location of PII table for survey data processing')
 
     args = parser.parse_args(argv)

--- a/scripts/dpanon.py
+++ b/scripts/dpanon.py
@@ -5,6 +5,7 @@ import argparse as ap
 import sys
 from typing import Union, List
 from dpanonymize import dtype_module_dict
+import dpanonymize.surveys as SURVEYS
 import dpanonymize as dpanon
 
 '''
@@ -30,7 +31,7 @@ def lock_file(in_file: Union[Path, str],
 
 def lock_directory(in_dir: Union[Path, str],
                    out_dir: Union[Path, str],
-                   datatype: str) -> None:
+                   datatype: str, **kwargs) -> None:
     '''Remove PII from all files under a directory
 
     Requirements:
@@ -44,7 +45,17 @@ def lock_directory(in_dir: Union[Path, str],
     for in_file in Path(in_dir).glob('*'):
         if in_file.is_file():
             out_file = Path(out_dir) / in_file.name
-            module.remove_pii(in_file, out_file)
+            if datatype == 'surveys':
+                pii_table_loc = kwargs.get('pii_table_loc', False)
+                # using the file name without extension as the subject_id input
+                # for the process_and_copy_db function
+                SURVEYS.process_and_copy_db(
+                        pii_table_loc,
+                        in_file.name.split('.')[0],
+                        in_file,
+                        out_file)
+            else:
+                module.remove_pii(in_file, out_file)
 
 
 def parse_args(argv):
@@ -64,9 +75,13 @@ def parse_args(argv):
                         help='A directory to remove PII from')
     parser.add_argument('-od', '--out_dir',
                         help='PII removed output dir path')
-    parser.add_argument('-dt', '--datatype',
-                        choices=['surveys', 'video', 'audio', 'actigraphy', 'mri', 'eeg'],
-                        help='Datatype to remove PII (applies to -p, -i).')
+    parser.add_argument(
+            '-dt', '--datatype',
+            choices=['surveys', 'video', 'audio', 'actigraphy', 'mri', 'eeg'],
+            help='Datatype to remove PII (applies to -p, -i).')
+    parser.add_argument(
+            '-ptl', '--pii_table_loc', default=False,
+            help='Location of PII table for survey data processing')
 
     args = parser.parse_args(argv)
 
@@ -75,21 +90,31 @@ def parse_args(argv):
 
     if args.in_dir and args.datatype is None:
         parser.error('--in_file and --datatype always appear together')
-    
+
     return args
 
 
 def dpanonymize(args):
     if args.phoenix_root:
         in_dict = {'phoenix_root': args.phoenix_root, 'BIDS': args.bids}
-        dpanon.lock_lochness(in_dict, args.datatype)
+        dpanon.lock_lochness(in_dict, args.datatype,
+                             pii_table_loc=args.pii_table_loc)
 
     else:
         if args.in_file:
-            lock_file(args.in_file, args.out_file, args.datatype)
+            if args.datatype == 'surveys':
+                print('hahah')
+                SURVEYS.process_and_copy_db(
+                        args.pii_table_loc,
+                        Path(args.in_file).name.split('.')[0],
+                        args.in_file,
+                        args.out_file)
+            else:
+                lock_file(args.in_file, args.out_file, args.datatype)
 
         if args.in_dir:
-            lock_directory(args.in_dir, args.out_dir, args.datatype)
+            lock_directory(args.in_dir, args.out_dir, args.datatype,
+                           pii_table_loc=args.pii_table_loc)
 
 
 if __name__ == '__main__':

--- a/tests/scripts/test_dpanon.py
+++ b/tests/scripts/test_dpanon.py
@@ -66,7 +66,7 @@ def test_phoenix_root_non_bids_with_dt(phoenix_structure):
     args = parse_args(
             ['-p', 'tmp_phoenix',
              '-dt', 'surveys',
-             '-ptl', '/Users/kc244/dpanonymize/tests/pii_convert.csv'])
+             '-pt', '/Users/kc244/dpanonymize/tests/pii_convert.csv'])
 
     dpanonymize(args)
     show_tree_then_delete('tmp_phoenix')
@@ -77,7 +77,7 @@ def test_phoenix_root_bids_with_dt(phoenix_structure_BIDS):
     args = parse_args(
             ['-p', 'tmp_phoenix',
              '-dt', 'surveys',
-             '-ptl', '/Users/kc244/dpanonymize/tests/pii_convert.csv',
+             '-pt', '/Users/kc244/dpanonymize/tests/pii_convert.csv',
              '-b'])
 
     dpanonymize(args)
@@ -95,7 +95,7 @@ def test_file_with_dt():
         args = parse_args(
                 ['-i', str(in_file),
                  '-o', str(pii_removed_file),
-                 '-ptl', '/Users/kc244/dpanonymize/tests/pii_convert.csv',
+                 '-pt', '/Users/kc244/dpanonymize/tests/pii_convert.csv',
                  '-dt', datatype])
         dpanonymize(args)
         assert pii_removed_file.is_file()
@@ -117,7 +117,7 @@ def test_dir_with_dt():
         args = parse_args(
                 ['-id', str(temp_dir),
                  '-od', str(out_dir),
-                 '-ptl', '/Users/kc244/dpanonymize/tests/pii_convert.csv',
+                 '-pt', '/Users/kc244/dpanonymize/tests/pii_convert.csv',
                  '-dt', datatype])
         dpanonymize(args)
         assert out_dir.is_dir()

--- a/tests/scripts/test_dpanon.py
+++ b/tests/scripts/test_dpanon.py
@@ -23,7 +23,7 @@ from dpanon import lock_file, lock_directory, parse_args, dpanonymize
 
 
 def test_dpanonymize_a_file():
-    for datatype in 'mri', 'surveys', 'audio', 'video', 'actigraphy':
+    for datatype in 'mri', 'audio', 'video', 'actigraphy':
         in_file = Path(f'{datatype}_temp_file.dcm')
         in_file.touch()
 
@@ -36,9 +36,8 @@ def test_dpanonymize_a_file():
         os.remove(pii_removed_file)
 
 
-
 def test_dpanonymize_a_directory():
-    for datatype in 'mri', 'surveys', 'audio', 'video', 'actigraphy':
+    for datatype in 'mri', 'audio', 'video', 'actigraphy':
         temp_dir = Path(f'{datatype}_raw_dir')
         temp_dir.mkdir(exist_ok=True)
         
@@ -64,8 +63,10 @@ def test_parser():
 
 def test_phoenix_root_non_bids_with_dt(phoenix_structure):
     # with datatype
-    args = parse_args(['-p', 'tmp_phoenix',
-                       '-dt', 'surveys'])
+    args = parse_args(
+            ['-p', 'tmp_phoenix',
+             '-dt', 'surveys',
+             '-ptl', '/Users/kc244/dpanonymize/tests/pii_convert.csv'])
 
     dpanonymize(args)
     show_tree_then_delete('tmp_phoenix')
@@ -73,9 +74,11 @@ def test_phoenix_root_non_bids_with_dt(phoenix_structure):
 
 def test_phoenix_root_bids_with_dt(phoenix_structure_BIDS):
     # with datatype
-    args = parse_args(['-p', 'tmp_phoenix',
-                       '-dt', 'surveys',
-                       '-b'])
+    args = parse_args(
+            ['-p', 'tmp_phoenix',
+             '-dt', 'surveys',
+             '-ptl', '/Users/kc244/dpanonymize/tests/pii_convert.csv',
+             '-b'])
 
     dpanonymize(args)
     show_tree_then_delete('tmp_phoenix')
@@ -83,15 +86,17 @@ def test_phoenix_root_bids_with_dt(phoenix_structure_BIDS):
 
 def test_file_with_dt():
     for datatype in 'mri', 'surveys', 'audio', 'video', 'actigraphy':
-        in_file = Path(f'{datatype}_temp_file.dcm')
+        in_file = Path(f'{datatype}_temp_file.json')
         in_file.touch()
 
         pii_removed_file = Path('pii_removed_' + in_file.name)
 
         # with datatype
-        args = parse_args(['-i', str(in_file),
-                           '-o', str(pii_removed_file),
-                           '-dt', datatype])
+        args = parse_args(
+                ['-i', str(in_file),
+                 '-o', str(pii_removed_file),
+                 '-ptl', '/Users/kc244/dpanonymize/tests/pii_convert.csv',
+                 '-dt', datatype])
         dpanonymize(args)
         assert pii_removed_file.is_file()
 
@@ -104,14 +109,16 @@ def test_dir_with_dt():
         temp_dir = Path(f'{datatype}_raw_dir')
         temp_dir.mkdir(exist_ok=True)
         
-        in_file = temp_dir / f'{datatype}_temp_file.dcm'
+        in_file = temp_dir / f'{datatype}_temp_file.json'
         in_file.touch()
 
         out_dir = Path(f'{datatype}_pii_removed_dir')
 
-        args = parse_args(['-id', str(temp_dir),
-                           '-od', str(out_dir),
-                           '-dt', datatype])
+        args = parse_args(
+                ['-id', str(temp_dir),
+                 '-od', str(out_dir),
+                 '-ptl', '/Users/kc244/dpanonymize/tests/pii_convert.csv',
+                 '-dt', datatype])
         dpanonymize(args)
         assert out_dir.is_dir()
         assert (out_dir / in_file.name).is_file()


### PR DESCRIPTION
Since the dpanonymize framework (with the initial placeholder of copying files) is ready, we need to work on each data type modules to replace the initial placeholder with working PII removal code. 

This PR is for the PII removal of survey data. Most of the parts have already been reviewed by Tashrif in the `AMP-SCZ/lochness` repository. https://github.com/AMP-SCZ/lochness/pull/13 (PII removal was initially included in the `lochness` repo, before spinning out to this new repo).

Relevant functions which are involved in the survey PII removal now take either `pii_table_loc` or its equivalent in the `kwargs`, which is used to refer to how each PII sensitive field should be processed.

