### PR TITLE
Kcho/update path detection to use regrex

### DIFF
--- a/dpanonymize/__init__.py
+++ b/dpanonymize/__init__.py
@@ -8,6 +8,7 @@ import dpanonymize.actigraphy as ACTIGRAPHY
 import dpanonymize.mri as MRI
 import dpanonymize.video as VIDEO
 import dpanonymize.audio as AUDIO
+import dpanonymize.eeg as EEG
 
 
 dtype_module_dict = {
@@ -16,7 +17,8 @@ dtype_module_dict = {
     'mri': MRI,
     'interviews': VIDEO,
     'audio': AUDIO,
-    'video': VIDEO
+    'video': VIDEO,
+    'eeg': EEG
 }
 
 
@@ -59,7 +61,7 @@ class FileInPhoenixBIDS(object):
             module.remove_pii(self.file_path, self.general_path)
 
     def __repr__(self):
-        return f"<{self.file_path.name}>"
+        return f"<{self.file_path.name} {self.dtype}"
 
 
 class FileInPhoenix(FileInPhoenixBIDS):

--- a/dpanonymize/__init__.py
+++ b/dpanonymize/__init__.py
@@ -58,7 +58,7 @@ class FileInPhoenixBIDS(object):
             module.remove_pii(self.file_path, self.general_path)
 
     def __repr__(self):
-        return f"<{self.file_path.name} {self.dtype}"
+        return f"<{self.file_path.name} {self.dtype}>"
 
 
 class FileInPhoenix(FileInPhoenixBIDS):

--- a/dpanonymize/__init__.py
+++ b/dpanonymize/__init__.py
@@ -8,6 +8,7 @@ import dpanonymize.actigraphy as ACTIGRAPHY
 import dpanonymize.mri as MRI
 import dpanonymize.video as VIDEO
 import dpanonymize.audio as AUDIO
+import dpanonymize.eeg as EEG
 
 
 dtype_module_dict = {
@@ -16,7 +17,8 @@ dtype_module_dict = {
     'mri': MRI,
     'interviews': VIDEO,
     'audio': AUDIO,
-    'video': VIDEO
+    'video': VIDEO,
+    'eeg': EEG
 }
 
 
@@ -46,7 +48,7 @@ class FileInPhoenixBIDS(object):
         module.remove_pii(self.file_path, self.general_path)
 
     def __repr__(self):
-        return f"<{self.file_path.name}>"
+        return f"<{self.file_path.name} {self.dtype}"
 
 
 class FileInPhoenix(FileInPhoenixBIDS):

--- a/dpanonymize/__init__.py
+++ b/dpanonymize/__init__.py
@@ -140,6 +140,8 @@ def lock_lochness(Lochness: 'Lochness',
             })
         pii_table_loc = phoenix_root.parent / 'pii_convert.csv'
         df.to_csv(pii_table_loc)
+        kwargs['pii_table_loc'] =  pii_table_loc
+
 
     # get_file_objects_from_phoenix and get_file_objects_from_module takes
     # PROTECTED path, but FileInPhoenixBIDS and FileInPhoenix are designed
@@ -149,5 +151,5 @@ def lock_lochness(Lochness: 'Lochness',
         get_file_objects_from_module(protected_root, module, bids)
     
     for file_object in file_object_list:
-        file_object.anonymize(pii_table_loc=pii_table_loc, **kwargs)
+        file_object.anonymize(**kwargs)
 

--- a/dpanonymize/__init__.py
+++ b/dpanonymize/__init__.py
@@ -31,9 +31,7 @@ class FileInPhoenixBIDS(object):
           Example file_path
               /Some/Path/PROTECTED/BWH/raw/subject01/actigraphy/file
               /Some/Path/PROTECTED/BWH/processed/subject01/actigraphy/file
-
-    Also works with files under extra folders under the dtype root folder
-    /Some/Path/PROTECTED/BWH/processed/subject01/actigraphy/extra_folder/file
+              /Some/Path/PROTECTED/BWH/processed/subject01/actigraphy/Some/Path/file
     '''
     def __init__(self, file_path: str):
         search = re.search(r'PROTECTED\/'
@@ -91,9 +89,7 @@ class FileInPhoenix(FileInPhoenixBIDS):
           Example file_path
               /Some/Path/PROTECTED/BWH/subject01/actigraphy/processed/file
               /Some/Path/PROTECTED/BWH/subject01/actigraphy/raw/file
-
-    Also works with files under extra folders under the dtype root folder
-    /Some/Path/PROTECTED/BWH/processed/subject01/actigraphy/extra_folder/file
+              /Some/Path/PROTECTED/BWH/processed/subject01/actigraphy/Some/Path/file
     '''
     def __init__(self, file_path: str):
         super().__init__(file_path)

--- a/dpanonymize/__init__.py
+++ b/dpanonymize/__init__.py
@@ -31,6 +31,9 @@ class FileInPhoenixBIDS(object):
           Example file_path
               /Some/Path/PROTECTED/BWH/raw/subject01/actigraphy/file
               /Some/Path/PROTECTED/BWH/processed/subject01/actigraphy/file
+
+    Also works with files under extra folders under the dtype root folder
+    /Some/Path/PROTECTED/BWH/processed/subject01/actigraphy/extra_folder/file
     '''
     def __init__(self, file_path: str):
         search = re.search(r'PROTECTED\/'
@@ -88,6 +91,9 @@ class FileInPhoenix(FileInPhoenixBIDS):
           Example file_path
               /Some/Path/PROTECTED/BWH/subject01/actigraphy/processed/file
               /Some/Path/PROTECTED/BWH/subject01/actigraphy/raw/file
+
+    Also works with files under extra folders under the dtype root folder
+    /Some/Path/PROTECTED/BWH/processed/subject01/actigraphy/extra_folder/file
     '''
     def __init__(self, file_path: str):
         super().__init__(file_path)

--- a/dpanonymize/__init__.py
+++ b/dpanonymize/__init__.py
@@ -8,6 +8,7 @@ import dpanonymize.actigraphy as ACTIGRAPHY
 import dpanonymize.mri as MRI
 import dpanonymize.video as VIDEO
 import dpanonymize.audio as AUDIO
+import dpanonymize.eeg as EEG
 import pandas as pd
 
 
@@ -17,7 +18,8 @@ dtype_module_dict = {
     'mri': MRI,
     'interviews': VIDEO,
     'audio': AUDIO,
-    'video': VIDEO
+    'video': VIDEO,
+    'eeg': EEG
 }
 
 
@@ -56,7 +58,7 @@ class FileInPhoenixBIDS(object):
             module.remove_pii(self.file_path, self.general_path)
 
     def __repr__(self):
-        return f"<{self.file_path.name}>"
+        return f"<{self.file_path.name} {self.dtype}"
 
 
 class FileInPhoenix(FileInPhoenixBIDS):

--- a/dpanonymize/eeg/__init__.py
+++ b/dpanonymize/eeg/__init__.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+import shutil
+from typing import Union
+
+def remove_pii(data_in: Union[str, Path], data_out: Union[str, Path]):
+    '''Remove PII from eeg data - place holder'''
+    if not Path(data_out).parent.is_dir():
+        Path(data_out).parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy(data_in, data_out)
+


### PR DESCRIPTION
I have noticed that `lochness.XNAT` module will download data to a subdirectory (eg- 2001_MR1) under `mri` directory in the phoenix structure. It could also be the case that other teams may add extra subdirectories under `box` and `mediaflux` as well. To account for this extra level of directories under the datatype directory, I've updated `FileInPhoenixBIDS` and `FileInPhoenix` classes to use regrex to be more flexible under these situations. Tested using `pytest test/dpanonymize/test_dpanonymize.py`.

Thanks.